### PR TITLE
fix: use single number system

### DIFF
--- a/src/Bip32PrivateKey.ts
+++ b/src/Bip32PrivateKey.ts
@@ -24,9 +24,16 @@ export default class Bip32PrivateKey {
         if (err) {
           reject(err);
         }
-        xprv[0] &= 248;
-        xprv[31] &= 0x1f;
-        xprv[31] |= 64;
+        // The lowest three bits of the first octet are cleared
+        // 248 or 0xf8 or 0b11111000
+        xprv[0] &= 0b11111000;
+        // the highest bit of the last octet is cleared
+        // 31 or 0x1f or 0b00011111
+        // AND the third highest bit is cleared too
+        xprv[31] &= 0b00011111;
+        // and the second highest bit of the last octet is set
+        // 64 or 0x40 or 0b01000000
+        xprv[31] |= 0b01000000;
         resolve(new Bip32PrivateKey(xprv));
       });
     });


### PR DESCRIPTION
This PR is just a clarification for somebody who are reading the code.

In continue of https://github.com/StricaHQ/bip32ed25519/pull/7

---

The section V->A of specification told us:

> If the third highest bit of the last byte of kL is not zero, **discard k**.

But in reference implementation of [CIP3](https://cips.cardano.org/cips/cip3/) mentioned `_force` way of key generation: `normalize_bytes_force3rd` https://docs.rs/ed25519-bip32/latest/src/ed25519_bip32/key.rs.html#53

So current implementation is matched one of the approaches.