### PR TITLE
Add fromSecretKey to PrivateKey Class

### DIFF
--- a/src/PrivateKey.ts
+++ b/src/PrivateKey.ts
@@ -9,7 +9,7 @@ const eddsa = new EDDSA();
 export default class PrivateKey {
   private privKey: Buffer;
 
-  constructor(privKey: Buffer, extended: Boolean = true) {
+  constructor(privKey: Buffer) {
     this.privKey = privKey;
   }
 

--- a/src/PrivateKey.ts
+++ b/src/PrivateKey.ts
@@ -2,14 +2,23 @@ import { Buffer } from "buffer";
 import PublicKey from "./PublicKey";
 
 const EDDSA = require("./ed25519e");
+const hash = require("hash.js");
 
 const eddsa = new EDDSA();
 
 export default class PrivateKey {
   private privKey: Buffer;
 
-  constructor(privKey: Buffer) {
-    this.privKey = privKey;
+  constructor(privKey: Buffer, extended: Boolean = true) {
+    if (extended) {
+      this.privKey = privKey;
+    } else {
+      let extendedSecret = hash.sha512().update(privKey).digest();
+      extendedSecret[0] &= 0b1111_1000;
+      extendedSecret[31] &= 0b0011_1111;
+      extendedSecret[31] |= 0b0100_0000;
+      this.privKey = extendedSecret;
+    }
   }
 
   toBytes(): Buffer {

--- a/src/PrivateKey.ts
+++ b/src/PrivateKey.ts
@@ -1,8 +1,8 @@
 import { Buffer } from "buffer";
+import { sha512 } from "./utils";
 import PublicKey from "./PublicKey";
 
 const EDDSA = require("./ed25519e");
-const hash = require("hash.js");
 
 const eddsa = new EDDSA();
 
@@ -10,15 +10,15 @@ export default class PrivateKey {
   private privKey: Buffer;
 
   constructor(privKey: Buffer, extended: Boolean = true) {
-    if (extended) {
-      this.privKey = privKey;
-    } else {
-      let extendedSecret = hash.sha512().update(privKey).digest();
-      extendedSecret[0] &= 0b1111_1000;
-      extendedSecret[31] &= 0b0011_1111;
-      extendedSecret[31] |= 0b0100_0000;
-      this.privKey = extendedSecret;
-    }
+    this.privKey = privKey;
+  }
+
+  static fromSecretKey(secretKey: Buffer): PrivateKey {
+    let extendedSecret = sha512(secretKey);
+    extendedSecret[0] &= 0b1111_1000;
+    extendedSecret[31] &= 0b0011_1111;
+    extendedSecret[31] |= 0b0100_0000;
+    return new PrivateKey(extendedSecret);
   }
 
   toBytes(): Buffer {

--- a/src/ed25519e/key.js
+++ b/src/ed25519e/key.js
@@ -47,7 +47,6 @@ function KeyPair(eddsa, params) {
   this.eddsa = eddsa;
   this._secret = parseBytes(params.secret);
   if (eddsa.isPoint(params.pub)) {
-    console.log("Its point");
     this._pub = params.pub;
   } else {
     this._pubBytes = parseBytes(params.pub);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -14,3 +14,8 @@ export const hmac512 = function (key: Buffer, data: Buffer): Buffer {
     .digest();
   return Buffer.from(digest);
 };
+
+export const sha512 = function (data: Buffer): Buffer {
+  let digest = hashJs.sha512().update(data).digest();
+  return Buffer.from(digest);
+};

--- a/tests/main.spec.ts
+++ b/tests/main.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import { Bip32PrivateKey } from "../src/index";
+import { Bip32PrivateKey, PrivateKey } from "../src/index";
 
 describe("bip32ed25519", (): void => {
   describe("159ccb8c732a2cf226cc6895618926ff0fb391df", (): void => {
@@ -280,6 +280,16 @@ describe("bip32ed25519", (): void => {
           .toPublicKey()
           .verify(Buffer.from(sig, "hex"), Buffer.from(message, "hex"))
       ).eq(true);
+    });
+
+    it("generates expected public key with ed25519 private key", () => {
+      const pk = new PrivateKey(
+        Buffer.from("b7cbcc113d2fe1c6f97d858c2e512459b36034c67f630749567d8783757394c7", "hex"),
+        false
+      );
+      expect(Buffer.from(pk.toPublicKey().hash()).toString("hex")).eq(
+        "5ca51b304b1f79d92eada8c58c513e969458dcd27ce4f5bc47823ffa"
+      );
     });
   });
 });

--- a/tests/main.spec.ts
+++ b/tests/main.spec.ts
@@ -281,15 +281,32 @@ describe("bip32ed25519", (): void => {
           .verify(Buffer.from(sig, "hex"), Buffer.from(message, "hex"))
       ).eq(true);
     });
+  });
 
-    it("generates expected public key with ed25519 private key", () => {
-      const pk = new PrivateKey(
-        Buffer.from("b7cbcc113d2fe1c6f97d858c2e512459b36034c67f630749567d8783757394c7", "hex"),
-        false
-      );
-      expect(Buffer.from(pk.toPublicKey().hash()).toString("hex")).eq(
-        "5ca51b304b1f79d92eada8c58c513e969458dcd27ce4f5bc47823ffa"
-      );
+  describe("ed25519", (): void => {
+    describe("b7cbcc113d2fe1c6f97d858c2e512459b36034c67f630749567d8783757394c7", (): void => {
+      let privKey: PrivateKey;
+      before(async () => {
+        privKey = PrivateKey.fromSecretKey(
+          Buffer.from("b7cbcc113d2fe1c6f97d858c2e512459b36034c67f630749567d8783757394c7", "hex")
+        );
+      });
+
+      const expectedPublicKey = "5ca51b304b1f79d92eada8c58c513e969458dcd27ce4f5bc47823ffa";
+
+      const message = "15e7831b12b025a886a21f767f2aeecd5ad3220dd8c9de586284a04c545ecd04";
+      const expectedSig =
+        "6a88cc38cee78d8a2fafb5c8826f6be87686c60472e2a0eaac7576f7a7f51a5eeb0a65b9797975355e80dae1d91974ab59c301bb36edc27af676419ff269a10d";
+
+      it("generates expected public key with ed25519 private key", () => {
+        expect(Buffer.from(privKey.toPublicKey().hash()).toString("hex")).eq(expectedPublicKey);
+      });
+
+      it("generates expected signature with ed25519 private key and verify", () => {
+        const sig = privKey.sign(Buffer.from(message, "hex")).toString("hex");
+        expect(sig).eq(expectedSig);
+        expect(privKey.verify(Buffer.from(sig, "hex"), Buffer.from(message, "hex")));
+      });
     });
   });
 });


### PR DESCRIPTION
After generating an Ed25519 private key, some bit manipulation is needed before it can be used as a Bip32-Ed25519 secret. I have added a new function that derives the correct extended secret.